### PR TITLE
Frontend-jpic

### DIFF
--- a/BRAD/agent.py
+++ b/BRAD/agent.py
@@ -69,6 +69,9 @@ import json
 import logging
 import time
 from typing import Optional, List
+import pickle
+import atexit
+
 
 # Bioinformatics
 # import gget
@@ -250,6 +253,39 @@ class Agent():
     
         # Start loop
         self.state = log.userOutput('Welcome to RAG! The chat log from this conversation will be saved to ' + self.chatname + '. How can I help?', state=self.state)
+
+        # Ensure that the save_state function is registered to run at program exit
+        atexit.register(self.save_state)
+
+
+    def save_state(self):
+        """
+        Saves the agent state to a file named '.agent-state.pkl' in the output directory.
+        This method is registered with atexit to ensure it is called when the program exits.
+        """
+        # Auth: Joshua Pickard
+        #       jpic@umich.edu
+        # Date: October 15, 2024
+
+        output_directory = self.state['output-directory']
+        if not os.path.exists(output_directory):
+            os.makedirs(output_directory)
+
+        state_file = os.path.join(output_directory, '.agent-state.pkl')
+
+        try:
+            # Set the databases to none
+            print(self.state)
+            self.state['databases']['RAG'] = None
+            self.state['llm'] = None
+
+            # Save the state to a pickle file
+            with open(state_file, 'wb') as f:
+                pickle.dump(self.state, f)
+            logging.info(f"Agent state saved to {state_file}")
+        except Exception as e:
+            logging.error(f"Failed to save agent state: {e}")
+
 
     def invoke(self, query):
         """

--- a/BRAD/agent.py
+++ b/BRAD/agent.py
@@ -554,6 +554,23 @@ class Agent():
         self.state['interactive'] = False
         self.state = log.userOutput("Thanks for chatting today! I hope to talk soon, and don't forget that a record of this conversation is available at: " + self.chatname, state=self.state)
 
+    def get_display(self):
+        """
+        This function returns the history of all inputs/outputs to the agent. This is intended
+        for use by the GUI, as it will allow the user to jump between sessions while loading in
+        the history of the old session.
+
+        :returns: a list of strings
+        :rtype: list
+        """
+        # numIOpairs = len(self.chatlog.keys())
+        display = []
+        for i in self.chatlog.keys():
+            display.append(self.chatlog[i]['prompt'])
+            display.append(self.chatlog[i]['output'])
+        return display
+
+
     def updateMemory(self):
         """
         Thils function lets BRAD reset his memory to focus on specific previous interactions. This is useful

--- a/BRAD/agent.py
+++ b/BRAD/agent.py
@@ -149,6 +149,8 @@ class Agent():
     :type embeddings_model: HuggingFaceEmbeddings, optional
     :param max_api_calls: The maximum number of api / llm calls BRAD can make
     :type max_api_calls: int, optional
+    :param tools: The set of available tool modules. If None, all modules are available for use
+    :type tools: list, optional
 
     :raises FileNotFoundError: If the specified model or database directories do not exist.
     :raises json.JSONDecodeError: If the configuration file contains invalid JSON.
@@ -163,6 +165,7 @@ class Agent():
         ragvectordb=None,
         embeddings_model=None,
         restart=None,
+        tools=None,
         name='BRAD',
         max_api_calls=None, # This prevents BRAD from finding infinite loops and using all your API credits,
         interactive=True,   # This indicates if BRAD is in interactive more or not
@@ -251,7 +254,7 @@ class Agent():
         memory = ConversationBufferMemory(ai_prefix="BRAD")
     
         # Initialize the routers from router.py
-        self.router = getRouter()
+        self.router = getRouter(available=tools)
     
         # Add other information to state
         # Assign values only if the key does not exist or is None/empty

--- a/BRAD/router.py
+++ b/BRAD/router.py
@@ -172,11 +172,14 @@ def getRouterPath(file):
     file_path = os.path.join(current_script_dir, 'routers', file) #'enrichr.txt')
     return file_path
     
-def getRouter():
+def getRouter(available=None):
     """
     Constructs a semantic router layer configured to determine the correct tool module for user queries.
     This routing layer uses the routing files and previously used user inputs as data to predict which
     tool module to use. These routing files are updated over time.
+
+    :param available: list of avaialble modules. If available is `None`, then all modules are available by default.
+    :type available: list, optional
 
     :return: A router layer configured with predefined routes for tasks such as querying Enrichr, web scraping, and generating tables.
     :rtype: RouteLayer
@@ -185,64 +188,79 @@ def getRouter():
     # Auth: Joshua Pickard
     #       jpic@umich.edu
     # Date: May 16, 2024
-    routeGget = Route(
-        name = 'GGET',
-        utterances = read_prompts(getRouterPath('enrichr.txt'))
-    )
-    routeScrape = Route(
-        name = 'SCRAPE',
-        utterances = read_prompts(getRouterPath('scrape.txt'))
-    )
-    routeRAG = Route(
-        name = 'RAG',
-        utterances = read_prompts(getRouterPath('rag.txt'))
-    )
-    routeTable = Route(
-        name = 'TABLE',
-        utterances = read_prompts(getRouterPath('table.txt'))
-    )
-    routeData = Route(
-        name = 'DATA',
-        utterances = read_prompts(getRouterPath('data.txt'))
-    )
-    routeMATLAB = Route(
-        name = 'MATLAB',
-        utterances = read_prompts(getRouterPath('matlab.txt'))
-    )
-    routePython = Route(
-        name = 'PYTHON',
-        utterances = read_prompts(getRouterPath('python.txt'))
-    )
-    routePlanner = Route(
-        name = 'PLANNER',
-        utterances = read_prompts(getRouterPath('planner.txt'))
-    )
-    routeCode = Route(
-        name = 'CODE',
-        utterances = read_prompts(getRouterPath('code.txt'))
-    )
-    routeWrite = Route(
-        name = 'WRITE',
-        utterances = read_prompts(getRouterPath('write.txt'))
-    )
-    routeRoute = Route(
-        name = 'ROUTER',
-        utterances = read_prompts(getRouterPath('router.txt'))
-    )
+
+    # Dev. Comments:
+    # -------------------
+    #
+    # History:
+    # - 2024-05-16: first version of this method
+    # - 2024-10-15: this method is modified to allow a user to constrict
+    #               the set of modules available to an agent.
+
+    routes = []
+
+    # Digital Library
+    if available is None or 'GGET' in available:
+        routeGget = Route(
+            name = 'GGET',
+            utterances = read_prompts(getRouterPath('enrichr.txt'))
+        )
+        routes.append(routeGget)
+    if available is None or 'SCRAPE' in available:
+        routeScrape = Route(
+            name = 'SCRAPE',
+            utterances = read_prompts(getRouterPath('scrape.txt'))
+        )
+        routes.append(routeScrape)
+
+    # Lab Notebook
+    if available is None or 'RAG' in available:
+        routeRAG = Route(
+            name = 'RAG',
+            utterances = read_prompts(getRouterPath('rag.txt'))
+        )
+        routes.append(routeRAG)
+
+    # SOFTWARE
+    if available is None or 'CODE' in available:
+        routeCode = Route(
+            name = 'CODE',
+            utterances = read_prompts(getRouterPath('code.txt'))
+        )
+        routes.append(routeCode)
+    if available is None or 'PYTHON' in available:
+        routePython = Route(
+            name = 'PYTHON',
+            utterances = read_prompts(getRouterPath('python.txt'))
+        )
+        routes.append(routePython)
+
+    # Additional Core Modules
+    if available is None or 'PLANNER' in available:
+        routePlanner = Route(
+            name = 'PLANNER',
+            utterances = read_prompts(getRouterPath('planner.txt'))
+        )
+        routes.append(routePlanner)
+    if available is None or 'WRITE' in available:
+        routeWrite = Route(
+            name = 'WRITE',
+            utterances = read_prompts(getRouterPath('write.txt'))
+        )
+        routes.append(routeWrite)
+    if available is None or 'ROUTER' in available:
+        routeRoute = Route(
+            name = 'ROUTER',
+            utterances = read_prompts(getRouterPath('router.txt'))
+        )
+        routes.append(routeRoute)
+
+    # Encoder to embed the routeing examples
     encoder = HuggingFaceEncoder(device='cpu')
-    routes = [routeGget,
-              routeScrape,
-              routeTable,
-              routeRAG,
-              routeData,
-              routeMATLAB,
-              routePython,
-              routePlanner,
-              routeCode,
-              routeWrite,
-              routeRoute
-             ]
+
+    # Construct route layer
     router = RouteLayer(encoder=encoder, routes=routes)    
+
     return router
 
 def buildRoutes(prompt):

--- a/app.py
+++ b/app.py
@@ -64,7 +64,7 @@ def get_open_sessions():
     # Date: October 14, 2024
 
     # Get path to output directories
-    path_to_output_directories = brad.chatstatus['config']['log_path']
+    path_to_output_directories = brad.state['config']['log_path']
     
     # Get list of directories at this location
     try:

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 # STANDARD python imports
 import os
 import json
+import shutil
 
 # Imports for building RESTful API
 from flask import Flask, request, jsonify
@@ -72,7 +73,9 @@ def get_open_sessions():
                          if os.path.isdir(os.path.join(path_to_output_directories, name))]
         
         # Return the list of open sessions as a JSON response
-        return jsonify({"open_sessions": open_sessions})
+        message = jsonify({"open_sessions": open_sessions})
+        print(f"{message=}")
+        return message
     
     except FileNotFoundError:
         return jsonify({"error": "Directory not found"})
@@ -80,3 +83,22 @@ def get_open_sessions():
     except Exception as e:
         return jsonify({"error": str(e)})
 
+@app.route("/remove_sessions", methods=['POST'])
+def remove_open_sessions():
+    request_data = request.json
+    session = request_data.get("message")  # Get the session name from the request
+    path_to_output_directories = brad.state['config']['log_path']
+
+    # Construct the full path to the session directory
+    session_path = os.path.join(path_to_output_directories, session)
+
+    # Check if the session directory exists
+    if os.path.exists(session_path):
+        try:
+            # Remove the session directory
+            shutil.rmtree(session_path)
+            return jsonify({"success": True, "message": f"Session '{session}' removed."}), 200
+        except Exception as e:
+            return jsonify({"success": False, "message": str(e)}), 500
+    else:
+        return jsonify({"success": False, "message": f"Session '{session}' does not exist."}), 404

--- a/brad-chat/src/App.css
+++ b/brad-chat/src/App.css
@@ -1,11 +1,9 @@
-
 body {
   width: 100%;
   height: 100%;
   position: absolute;
   background-color: #212121;
-  /* font-family: 'Trebuchet MS', sans-serif; */
-  font-family: 'AR One Sans';
+  font-family: 'AR One Sans';  /* font-family: 'Trebuchet MS', sans-serif; */
   color: #f7f7f7;
 }
 
@@ -34,6 +32,12 @@ body {
   word-spacing: 2px;
 }
 
+/* Flex container to align the sidebar and chat container horizontally */
+.Content {
+  display: flex;
+  flex-grow: 1;    /* Makes the content area grow to fill the remaining space after the header */
+}
+
 .chat-container {
   display: flex;
   /* width: 100%; */
@@ -47,64 +51,51 @@ body {
 }
 
 .chat-sessions {
-  /* Set the background color of the sidebar to black */
-  background-color: #000000;  
-  /* Set the text color to white */
-  color: #FFFFFF;  
-  /* Optionally, set padding for inner spacing */
-  padding: 10px;  
-  /* Set font size (optional) */
-  font-size: 16px;  
-  /* Set the width of the sidebar (optional) */
-  width: 250px;    
-  /* Add a border (optional, for aesthetics) */
-  border: 1px solid #000000;
+  background-color: #000000;      /* Set the background color of the sidebar to black */
+  color: #FFFFFF;                 /* Set the text color to white */
+  padding: 10px;                  /* Optionally, set padding for inner spacing */
+  font-size: 16px;                /* Set font size (optional) */
+  width: 250px;                   /* Set the width of the sidebar (optional) */
+  border: 1px solid #000000;      /* Add a border (optional, for aesthetics) */
 }
 
-/* Flex container to align the sidebar and chat container horizontally */
-.Content {
-  display: flex;
-  flex-grow: 1; /* Makes the content area grow to fill the remaining space after the header */
+.sidebar-left {
+  background-color: #000000; /* Set the background color of the sidebar to black */
+  color: #FFFFFF;            /* Set the text color to white */
+  padding: 10px;               /* Optionally, set padding for inner spacing */
+  font-size: 16px;             /* Set font size (optional) */
+  width: 250px;                /* Set the width of the sidebar (optional) */
+  border: 1px solid #FFFFFF; /* Add a border (optional, for aesthetics) */
+  display: flex;               /* Enable Flexbox */
+  flex-direction: column;      /* Arrange items vertically */
+  align-items: center;         /* Center items horizontally */
+  justify-content: flex-start; /* Align items to the top */
+  overflow: hidden;            /* Prevent content from overflowing */
+  height: 100vh;               /* Optional: Set the height to full view height */
 }
 
-
-.left-sidebar {
-  /* Set the background color of the sidebar to black */
-  background-color: #000000;  
-  /* Set the text color to white */
-  color: #FFFFFF;  
-  /* Optionally, set padding for inner spacing */
-  padding: 10px;  
-  /* Set font size (optional) */
-  font-size: 16px;  
-  /* Set the width of the sidebar (optional) */
-  width: 250px;    
-  /* Add a border (optional, for aesthetics) */
-  border: 1px solid #FFFFFF;
-}
-
-.right-sidebar {
-  /* Set the background color of the sidebar to black */
-  background-color: #000000;  
-  /* Set the text color to white */
-  color: #FFFFFF;  
-  /* Optionally, set padding for inner spacing */
-  padding: 10px;  
-  /* Set font size (optional) */
-  font-size: 16px;  
-  /* Set the width of the sidebar (optional) */
-  width: 250px;    
-  /* Add a border (optional, for aesthetics) */
-  border: 1px solid #FFFFFF;
+.sidebar-right {
+  background-color: #000000; /* Set the background color of the sidebar to black */
+  color: #FFFFFF;            /* Set the text color to white */
+  padding: 10px;               /* Optionally, set padding for inner spacing */
+  font-size: 16px;             /* Set font size (optional) */
+  width: 250px;                /* Set the width of the sidebar (optional) */
+  border: 1px solid #FFFFFF; /* Add a border (optional, for aesthetics) */
+  display: flex;               /* Enable Flexbox */
+  flex-direction: column;      /* Arrange items vertically */
+  align-items: center;         /* Center items horizontally */
+  justify-content: flex-start; /* Align items to the top */
+  overflow: hidden;            /* Prevent content from overflowing */
+  height: 100vh;               /* Optional: Set the height to full view height */
 }
 
 
 /* The main container for LeftSideBar and ChatContainer */
 .Main-container {
   display: flex;
-  flex-grow: 1; /* Make sure the main content grows to fill available space */
-  flex-direction: row; /* Place LeftSideBar and ChatContainer side by side */
-  align-items: stretch; /* Ensure the height matches between LeftSideBar and ChatContainer */
+  flex-grow: 1;                /* Make sure the main content grows to fill available space */
+  flex-direction: row;         /* Place LeftSideBar and ChatContainer side by side */
+  align-items: stretch;        /* Ensure the height matches between LeftSideBar and ChatContainer */
   justify-content: flex-start; /* Align the items horizontally from the start */
 }
 
@@ -163,12 +154,6 @@ body {
   border-radius: 25px;
 }
 
-/* .message-list code {
-  overflow-y: auto;
-  text-wrap: ;
-} */
-
-
 /* Code Block styling with highlightjs */
 pre {
   white-space: pre-wrap;      
@@ -197,18 +182,18 @@ pre > code {
 /* Each session box styling */
 .session-box {
   height: 25px;
-  background-color: #f0f0f0;  /* Light grey background */
-  padding: 15px;              /* Padding inside the box */
-  border-radius: 10px;         /* Rounded corners */
+  background-color: #f0f0f0;                 /* Light grey background */
+  padding: 15px;                               /* Padding inside the box */
+  border-radius: 10px;                         /* Rounded corners */
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);  /* Subtle shadow for depth */
-  margin-bottom: 10px;         /* Space between session boxes */
-  position: relative;          /* Position to allow delete button absolute positioning */
+  margin-bottom: 10px;                         /* Space between session boxes */
+  position: relative;                          /* Position to allow delete button absolute positioning */
   transition: background-color 0.3s ease;
-  cursor: pointer;             /* Cursor changes to pointer on hover */
-  color: black;               /* Text color */
-  display: flex;              /* Use flexbox to align text */
-  align-items: center;        /* Vertically center the text */
-  justify-content: flex-start;  /* Align text to the right horizontally */
+  cursor: pointer;                             /* Cursor changes to pointer on hover */
+  color: black;                              /* Text color */
+  display: flex;                               /* Use flexbox to align text */
+  align-items: center;                         /* Vertically center the text */
+  justify-content: flex-start;                 /* Align text to the right horizontally */
 }
 
 /* Hover effect for session box */
@@ -223,8 +208,8 @@ pre > code {
   right: 10px;                 /* Align to the right */
   top: 50%;                    /* Vertically centered */
   transform: translateY(-50%); /* Ensure perfect centering */
-  background-color: #ff4d4d;   /* Red button background */
-  color: white;                /* White text */
+  background-color: #ff4d4d; /* Red button background */
+  color: white;              /* White text */
   border: none;
   padding: 5px 10px;
   border-radius: 5px;

--- a/brad-chat/src/App.css
+++ b/brad-chat/src/App.css
@@ -83,6 +83,31 @@ body {
   border: 1px solid #FFFFFF;
 }
 
+.right-sidebar {
+  /* Set the background color of the sidebar to black */
+  background-color: #000000;  
+  /* Set the text color to white */
+  color: #FFFFFF;  
+  /* Optionally, set padding for inner spacing */
+  padding: 10px;  
+  /* Set font size (optional) */
+  font-size: 16px;  
+  /* Set the width of the sidebar (optional) */
+  width: 250px;    
+  /* Add a border (optional, for aesthetics) */
+  border: 1px solid #FFFFFF;
+}
+
+
+/* The main container for LeftSideBar and ChatContainer */
+.Main-container {
+  display: flex;
+  flex-grow: 1; /* Make sure the main content grows to fill available space */
+  flex-direction: row; /* Place LeftSideBar and ChatContainer side by side */
+  align-items: stretch; /* Ensure the height matches between LeftSideBar and ChatContainer */
+  justify-content: flex-start; /* Align the items horizontally from the start */
+}
+
 .message-list {
   flex: 1;
   overflow-y: auto;
@@ -160,4 +185,53 @@ pre > code {
 .rag-file-upload {
   border: 10px #f4ebdb;
   background-color: #f4ebdb;
+}
+
+/* General container for the session list */
+.session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px; /* Space between each session box */
+}
+
+/* Each session box styling */
+.session-box {
+  height: 25px;
+  background-color: #f0f0f0;  /* Light grey background */
+  padding: 15px;              /* Padding inside the box */
+  border-radius: 10px;         /* Rounded corners */
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);  /* Subtle shadow for depth */
+  margin-bottom: 10px;         /* Space between session boxes */
+  position: relative;          /* Position to allow delete button absolute positioning */
+  transition: background-color 0.3s ease;
+  cursor: pointer;             /* Cursor changes to pointer on hover */
+  color: black;               /* Text color */
+  display: flex;              /* Use flexbox to align text */
+  align-items: center;        /* Vertically center the text */
+  justify-content: flex-start;  /* Align text to the right horizontally */
+}
+
+/* Hover effect for session box */
+.session-box:hover {
+  background-color: #797979;   /* Slightly darker on hover */
+}
+
+/* Delete button styling */
+.delete-btn {
+  display: none;               /* Hidden by default */
+  position: absolute;          /* Absolute to position it inside the session box */
+  right: 10px;                 /* Align to the right */
+  top: 50%;                    /* Vertically centered */
+  transform: translateY(-50%); /* Ensure perfect centering */
+  background-color: #ff4d4d;   /* Red button background */
+  color: white;                /* White text */
+  border: none;
+  padding: 5px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+/* Show delete button on hover */
+.session-box:hover .delete-btn {
+  display: block;              /* Make delete button visible on hover */
 }

--- a/brad-chat/src/App.css
+++ b/brad-chat/src/App.css
@@ -46,6 +46,28 @@ body {
   align-items: center;
 }
 
+.chat-sessions {
+  /* Set the background color of the sidebar to black */
+  background-color: #000000;  
+  /* Set the text color to white */
+  color: #FFFFFF;  
+  /* Optionally, set padding for inner spacing */
+  padding: 10px;  
+  /* Set font size (optional) */
+  font-size: 16px;  
+  /* Set the width of the sidebar (optional) */
+  width: 250px;    
+  /* Add a border (optional, for aesthetics) */
+  border: 1px solid #000000;
+}
+
+/* Flex container to align the sidebar and chat container horizontally */
+.Content {
+  display: flex;
+  flex-grow: 1; /* Makes the content area grow to fill the remaining space after the header */
+}
+
+
 .left-sidebar {
   /* Set the background color of the sidebar to black */
   background-color: #000000;  

--- a/brad-chat/src/App.js
+++ b/brad-chat/src/App.js
@@ -1,12 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ChatContainer from './components/ChatContainer';
 import LeftSideBar from './components/LeftSideBar';
-import RightSideBar from './components/RightSideBar';
 import './App.css';
 
-
-
 function App() {
+  const [messages, setMessages] = useState([]);  // Messages now managed in App
+
+  const handleSendMessage = async (message) => {
+    // Add the user's message to the message list
+    setMessages([...messages, { id: Date.now(), text: message, sender: 'user' }]);
+
+    let data = { "message": message };
+
+    try {
+      // Call the backend API using fetch
+      const response = await fetch('/api/invoke', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      // Parse the JSON response
+      const result = await response.json();
+      let bot_response = result['response'];
+
+      // Add the bot's response to the message list
+      setMessages((prevMessages) => [
+        ...prevMessages, 
+        { id: Date.now(), text: bot_response, sender: 'bot' }
+      ]);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  };
 
   return (
     <div className="App">
@@ -14,14 +42,12 @@ function App() {
         <h2>{String.fromCodePoint('0x1f916')} BRAD </h2>
       </header>
       <div className="Main-container">
-        <LeftSideBar />
-        <ChatContainer />
-        <RightSideBar />
+        <LeftSideBar setMessages={setMessages}/>
+        {/* Pass messages and handleSendMessage to ChatContainer */}
+        <ChatContainer messages={messages} onSendMessage={handleSendMessage} />
       </div>
     </div>
   );
-
 }
 
 export default App;
-

--- a/brad-chat/src/App.js
+++ b/brad-chat/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ChatContainer from './components/ChatContainer';
 import LeftSideBar from './components/LeftSideBar';
+import RightSideBar from './components/RightSideBar';
 import './App.css';
 
 
@@ -12,10 +13,14 @@ function App() {
       <header className="App-header">
         <h2>{String.fromCodePoint('0x1f916')} BRAD </h2>
       </header>
-      <LeftSideBar />
-      <ChatContainer />
+      <div className="Main-container">
+        <LeftSideBar />
+        <ChatContainer />
+        <RightSideBar />
+      </div>
     </div>
   );
+
 }
 
 export default App;

--- a/brad-chat/src/components/ChatContainer.js
+++ b/brad-chat/src/components/ChatContainer.js
@@ -1,53 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import MessageList from './MessageList';
 import MessageInput from './MessageInput';
-
 import "highlight.js/styles/github.css";
 import hljs from "highlight.js";
 import RagFileInput from './RagFileInput';
 
-function ChatContainer() {
-  const [messages, setMessages] = useState([]);
-
+function ChatContainer({ messages, onSendMessage }) {
+  // UseEffect to highlight syntax when messages change
   useEffect(() => {
     hljs.highlightAll();
   }, [messages]);
 
-  const handleSendMessage = async (message) => {
-    setMessages([...messages, { id: Date.now(), text: message, sender: 'user' }]);
-    
-    console.log("1. setting messages", message)
-
-    let data = {"message": message}
-    try {
-        // Call the backend API using fetch
-        const response = await fetch('/api/invoke', {
-          method: 'POST', // or 'GET' depending on your API
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(data), // Send the form data as a JSON payload
-        });
-        console.log("2. got response", response)
-  
-        // Parse the JSON response
-        const result = await response.json();
-        let bot_response = result['response']
-  
-        // Handle the response
-         // Set the API response to the state
-        setMessages((messages) => [...messages, { id: Date.now(), text: bot_response, sender: 'bot' }]);
-    } catch (error) {
-        console.error('Error:', error);
-    }
-
-  };
-
   return (
     <div className="chat-container">
       <RagFileInput />
+      {/* Display the messages */}
       <MessageList messages={messages} />
-      <MessageInput onSendMessage={handleSendMessage}/>
+      {/* Pass the onSendMessage handler to MessageInput */}
+      <MessageInput onSendMessage={onSendMessage} />
     </div>
   );
 }

--- a/brad-chat/src/components/ChatSessions.js
+++ b/brad-chat/src/components/ChatSessions.js
@@ -5,54 +5,71 @@ import "highlight.js/styles/github.css";
 function ChatSessions() {
   const [chatsessions, setSessions] = useState([]);
 
-  /* Whenever this component is mounted to the page, useEffect runs. This is React specific */
-  useEffect(() => {
-    const fetchSessions = async () => {
-      console.log("1. setting chatsessions", chatsessions);
+  // Function to handle session removal
+  const handleRemoveSession = async (sessionId) => {
+    try {
+      const response = await fetch('/api/remove_session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message: sessionId })
+      });
 
-      try {
-        // Call the backend API using fetch 
-        const response = await fetch('/api/open_sessions', {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          }
-        });
-
-        // Check if response is OK
-        if (!response.ok) {
-          throw new Error(`API request failed with status ${response.status}`);
-        }
-  
-        console.log("2. Received chat sessions response:", response);
-   
-        // Parse the JSON response
-        const result = await response.json();
-        
-        console.log("3. result", result);
-
-        // Collect new sessions and update the state
-        const newSessions = result['open_sessions'].map((session, index) => ({
-          id: `${Date.now()}-${index}`,  // Ensure unique IDs for each session
-          text: session,
-          sender: 'bot',
-        }));
-
-        // Set new sessions
-        setSessions((prevSessions) => [...prevSessions, ...newSessions]);
-
-      } catch (error) {
-        console.error('Error:', error);
+      if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
       }
-    };
 
+      console.log(`Session removed: ${sessionId}`);
+      
+      // Fetch the updated sessions after removal
+      await fetchSessions();
+
+    } catch (error) {
+      console.error('Error removing session:', error);
+    }
+  };
+
+  const fetchSessions = async () => {
+    console.log("1. setting chatsessions", chatsessions);
+
+    try {
+      const response = await fetch('/api/open_sessions', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
+
+      console.log("2. Received chat sessions response:", response);
+      const result = await response.json();
+      console.log("3. result", result);
+
+      const newSessions = result['open_sessions'].map((session, index) => ({
+        id: `${Date.now()}-${index}`,
+        text: session,
+        sender: 'bot',
+      }));
+
+      setSessions(newSessions);
+
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  };
+
+  useEffect(() => {
     fetchSessions();
   }, []); // Empty dependency array to run once on mount
 
   return (
     <div className="chat-sessions">
       <p>Chat Sessions</p>
-      <SessionList messages={chatsessions} />
+      <SessionList messages={chatsessions} onRemoveSession={handleRemoveSession} />
     </div>
   );
 }

--- a/brad-chat/src/components/ChatSessions.js
+++ b/brad-chat/src/components/ChatSessions.js
@@ -12,7 +12,7 @@ function ChatSessions() {
 
       try {
         // Call the backend API using fetch 
-        const response = await fetch('/open_sessions', {
+        const response = await fetch('/api/open_sessions', {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/brad-chat/src/components/ChatSessions.js
+++ b/brad-chat/src/components/ChatSessions.js
@@ -1,53 +1,58 @@
 import React, { useEffect, useState } from 'react';
-import MessageList from './MessageList';
-// import MessageInput from './MessageInput';
-
+import SessionList from './SessionList';
 import "highlight.js/styles/github.css";
-// import hljs from "highlight.js";
-// import RagFileInput from './RagFileInput';
 
 function ChatSessions() {
-
   const [chatsessions, setSessions] = useState([]);
 
   /* Whenever this component is mounted to the page, useEffect runs. This is React specific */
-  useEffect(() => {fetchSessions()}, []);
+  useEffect(() => {
+    const fetchSessions = async () => {
+      console.log("1. setting chatsessions", chatsessions);
 
-  const fetchSessions = async () => {
-    
-    console.log("1. setting chatsessions", chatsessions)
-
-    try {
-        // Call the backend API using fetch
+      try {
+        // Call the backend API using fetch 
         const response = await fetch('/open_sessions', {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
           }
         });
-        console.log("2. got chat sessions", response)
+
+        // Check if response is OK
+        if (!response.ok) {
+          throw new Error(`API request failed with status ${response.status}`);
+        }
   
+        console.log("2. Received chat sessions response:", response);
+   
         // Parse the JSON response
         const result = await response.json();
         
-        console.log("3. result", result)
+        console.log("3. result", result);
 
-        // Handle the response
-        // Set the API response to the state
-        for (let i = 0; i < result['open_sessions'].length / 2; i++) {
-            setSessions((chatsessions) => [...chatsessions, { id: Date.now(), text: result['open_sessions'][i], sender: 'bot' }]);
-        }
+        // Collect new sessions and update the state
+        const newSessions = result['open_sessions'].map((session, index) => ({
+          id: `${Date.now()}-${index}`,  // Ensure unique IDs for each session
+          text: session,
+          sender: 'bot',
+        }));
 
-    } catch (error) {
+        // Set new sessions
+        setSessions((prevSessions) => [...prevSessions, ...newSessions]);
+
+      } catch (error) {
         console.error('Error:', error);
-    }
+      }
+    };
 
-  };
+    fetchSessions();
+  }, []); // Empty dependency array to run once on mount
 
   return (
     <div className="chat-sessions">
       <p>Chat Sessions</p>
-      <MessageList messages={chatsessions} />
+      <SessionList messages={chatsessions} />
     </div>
   );
 }

--- a/brad-chat/src/components/ChatSessions.js
+++ b/brad-chat/src/components/ChatSessions.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import SessionList from './SessionList';
 import "highlight.js/styles/github.css";
 
-function ChatSessions() {
+function ChatSessions({ sessions, setMessages }) {
   const [chatsessions, setSessions] = useState([]);
 
   // Function to handle session removal
@@ -30,6 +30,35 @@ function ChatSessions() {
     }
   };
 
+
+  // Function to handle session change
+  const handleSessionChange = async (sessionId) => {
+    console.log(`Changing to session: ${sessionId}`);
+    const response = await fetch('/api/change_session', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: sessionId })
+    });
+  
+    if (response.ok) {
+      const data = await response.json();  // Get the response data
+      const formattedMessages = data.display.map((text, index) => ({
+        id: index, // Use index as a temporary unique key (for demo purposes)
+        text: text,
+        sender: index % 2 === 0 ? 'user' : 'bot' // Example: alternate between 'user' and 'bot'
+      }));
+  
+      setMessages(formattedMessages); // Set the formatted messages
+      console.log(`Session changed. Chat history:`, formattedMessages);
+  
+    } else {
+      console.error('Error changing session:', await response.json());
+    }
+  };
+  
+
   const fetchSessions = async () => {
     console.log("1. setting chatsessions", chatsessions);
 
@@ -42,7 +71,7 @@ function ChatSessions() {
       });
 
       if (!response.ok) {
-        throw new Error(`API request failed with status ${response.status}`);
+        throw new Error('API request failed with status ${response.status}');
       }
 
       console.log("2. Received chat sessions response:", response);
@@ -69,7 +98,7 @@ function ChatSessions() {
   return (
     <div className="chat-sessions">
       <p>Chat Sessions</p>
-      <SessionList messages={chatsessions} onRemoveSession={handleRemoveSession} />
+      <SessionList messages={chatsessions} onRemoveSession={handleRemoveSession} onChangeSession={handleSessionChange} />
     </div>
   );
 }

--- a/brad-chat/src/components/LeftSideBar.js
+++ b/brad-chat/src/components/LeftSideBar.js
@@ -1,53 +1,18 @@
 import React, { useEffect, useState } from 'react';
-// import MessageList from './MessageList';
-// import MessageInput from './MessageInput';
-
 import ChatSessions from './ChatSessions';
-
 import "highlight.js/styles/github.css";
 import hljs from "highlight.js";
-// import RagFileInput from './RagFileInput';
 
-function LeftSideBar() {
-  const [messages, setMessages] = useState([]);
+function LeftSideBar({ setMessages }) {
+  //const [messages, setMessages] = useState([]);
 
   useEffect(() => {
     hljs.highlightAll();
-  }, [messages]);
-
-  const handleSendMessage = async (message) => {
-    setMessages([...messages, { id: Date.now(), text: message, sender: 'user' }]);
-    
-    console.log("1. setting messages", message)
-
-    let data = {"message": message}
-    try {
-        // Call the backend API using fetch
-        const response = await fetch('/invoke', {
-          method: 'POST', // or 'GET' depending on your API
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(data), // Send the form data as a JSON payload
-        });
-        console.log("2. got response", response)
-  
-        // Parse the JSON response
-        const result = await response.json();
-        let bot_response = result['response']
-  
-        // Handle the response
-         // Set the API response to the state
-        setMessages((messages) => [...messages, { id: Date.now(), text: bot_response, sender: 'bot' }]);
-    } catch (error) {
-        console.error('Error:', error);
-    }
-
-  };
+  }, []);
 
   return (
     <div className="left-sidebar">
-      <ChatSessions />
+      <ChatSessions setMessages={setMessages} /> {/* Pass setMessages to ChatSessions */}
     </div>
   );
 }

--- a/brad-chat/src/components/RightSideBar.js
+++ b/brad-chat/src/components/RightSideBar.js
@@ -1,0 +1,14 @@
+import React, { useEffect, useState } from 'react';
+
+import "highlight.js/styles/github.css";
+import hljs from "highlight.js";
+
+function RightSideBar() {
+  return (
+    <div className="right-sidebar">
+      <h1>Right Sidebar</h1>
+    </div>
+  );
+}
+
+export default RightSideBar;

--- a/brad-chat/src/components/SessionList.js
+++ b/brad-chat/src/components/SessionList.js
@@ -3,33 +3,12 @@ import "highlight.js/styles/github.css";
 import Markdown from "marked-react";
 import '../App.css';  // Import the CSS file for custom styles
 
-function SessionList({ messages }) {
+function SessionList({ messages, onRemoveSession }) {
 
   // Function to handle session change
   const handleSessionChange = async (sessionId) => {
     try {
-      const response = await fetch('/change_session', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ session_id: sessionId })
-      });
-
-      if (!response.ok) {
-        throw new Error(`Error: ${response.statusText}`);
-      }
-
-      console.log(`Session changed to: ${sessionId}`);
-    } catch (error) {
-      console.error('Error changing session:', error);
-    }
-  };
-
-  // Function to handle session removal
-  const handleRemoveSession = async (sessionId) => {
-    try {
-      const response = await fetch('/api/remove_session', {
+      const response = await fetch('/api/change_session', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -41,9 +20,9 @@ function SessionList({ messages }) {
         throw new Error(`Error: ${response.statusText}`);
       }
 
-      console.log(`Session removed: ${sessionId}`);
+      console.log(`Session changed to: ${sessionId}`);
     } catch (error) {
-      console.error('Error removing session:', error);
+      console.error('Error changing session:', error);
     }
   };
 
@@ -62,7 +41,7 @@ function SessionList({ messages }) {
             className="delete-btn"
             onClick={(e) => {
               e.stopPropagation();  // Prevent triggering session change when delete is clicked
-              handleRemoveSession(message.text);  // Call remove session endpoint
+              onRemoveSession(message.text);  // Call remove session from parent
             }}
           >
             Delete

--- a/brad-chat/src/components/SessionList.js
+++ b/brad-chat/src/components/SessionList.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import "highlight.js/styles/github.css";
+import Markdown from "marked-react";
+
+function SessionList({ messages }) {
+
+  return (
+    <div className="session-list">
+      {messages.map((message) => (
+        <div key={message.id} className={`message ${message.sender}`}>
+          <Markdown>{message.text}</Markdown>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default SessionList;

--- a/brad-chat/src/components/SessionList.js
+++ b/brad-chat/src/components/SessionList.js
@@ -1,14 +1,72 @@
 import React from 'react';
 import "highlight.js/styles/github.css";
 import Markdown from "marked-react";
+import '../App.css';  // Import the CSS file for custom styles
 
 function SessionList({ messages }) {
+
+  // Function to handle session change
+  const handleSessionChange = async (sessionId) => {
+    try {
+      const response = await fetch('/change_session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ session_id: sessionId })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
+      }
+
+      console.log(`Session changed to: ${sessionId}`);
+    } catch (error) {
+      console.error('Error changing session:', error);
+    }
+  };
+
+  // Function to handle session removal
+  const handleRemoveSession = async (sessionId) => {
+    try {
+      const response = await fetch('/api/remove_session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message: sessionId })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Error: ${response.statusText}`);
+      }
+
+      console.log(`Session removed: ${sessionId}`);
+    } catch (error) {
+      console.error('Error removing session:', error);
+    }
+  };
 
   return (
     <div className="session-list">
       {messages.map((message) => (
-        <div key={message.id} className={`message ${message.sender}`}>
+        <div
+          key={message.id}
+          className="session-box"
+          onClick={() => handleSessionChange(message.text)}  // Session click
+        >
           <Markdown>{message.text}</Markdown>
+
+          {/* Delete button that appears on hover */}
+          <button
+            className="delete-btn"
+            onClick={(e) => {
+              e.stopPropagation();  // Prevent triggering session change when delete is clicked
+              handleRemoveSession(message.text);  // Call remove session endpoint
+            }}
+          >
+            Delete
+          </button>
         </div>
       ))}
     </div>

--- a/brad-chat/src/components/SessionList.js
+++ b/brad-chat/src/components/SessionList.js
@@ -1,30 +1,10 @@
+// SessionList.js
 import React from 'react';
 import "highlight.js/styles/github.css";
 import Markdown from "marked-react";
-import '../App.css';  // Import the CSS file for custom styles
+import '../App.css';
 
-function SessionList({ messages, onRemoveSession }) {
-
-  // Function to handle session change
-  const handleSessionChange = async (sessionId) => {
-    try {
-      const response = await fetch('/api/change_session', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ message: sessionId })
-      });
-
-      if (!response.ok) {
-        throw new Error(`Error: ${response.statusText}`);
-      }
-
-      console.log(`Session changed to: ${sessionId}`);
-    } catch (error) {
-      console.error('Error changing session:', error);
-    }
-  };
+function SessionList({ messages, onChangeSession, onRemoveSession }) {
 
   return (
     <div className="session-list">
@@ -32,16 +12,15 @@ function SessionList({ messages, onRemoveSession }) {
         <div
           key={message.id}
           className="session-box"
-          onClick={() => handleSessionChange(message.text)}  // Session click
+          onClick={() => onChangeSession(message.text)}  // Use onChangeSession prop
         >
           <Markdown>{message.text}</Markdown>
 
-          {/* Delete button that appears on hover */}
           <button
             className="delete-btn"
             onClick={(e) => {
-              e.stopPropagation();  // Prevent triggering session change when delete is clicked
-              onRemoveSession(message.text);  // Call remove session from parent
+              e.stopPropagation();
+              onRemoveSession(message.text);
             }}
           >
             Delete


### PR DESCRIPTION
a left side bar which displays previously opened chat sessions is displayed:
- API: New endpoints: `/remove_session` and `/change_sessions` delete and restart old chat sessions respectively
- BRAD Python:
    - the `Agent` class was modified to load and save the full system state (including memory) to a .pkl file when deleting the object
    - the `Agent` class has a new parameter `tools` which specify which tools are accessible to a single `Agent` for the GUI, `App.py` is modified to only allow the `Agent` to use the RAG at the moment.
    - the above change in tool module accessed required a change to `router.py` where the semantic router is built
- Front End:
    - Left and Right sidebars have been added. I think we should put configurations/RAG upload/available databases, etc. on the right hand side, and the left hand we could put the previous chat sessions and somewhere to put API keys from OpenAI and NVIDIA
    - the `messages` state and `setMessages` method was lifted to `App.js` from `ChatContainer.js` in order to allow `ChatSessions.js`, which lets the user turn on/off agents, to change which messages are being shown

BROKEN: this PR "breaks" the following items:
- the spacing doesn't look correct until the first message has been sent
- the scrolling bar for the messages has disappeared