### PR TITLE
Frontend llms

### DIFF
--- a/BRAD/endpoints.py
+++ b/BRAD/endpoints.py
@@ -85,6 +85,9 @@ from flask import Flask, request, jsonify, Blueprint
 from flask import flash, redirect, url_for
 from werkzeug.utils import secure_filename
 
+# Used to get list of OpenAI models
+from openai import OpenAI
+
 # Imports for BRAD library
 from BRAD.agent import Agent
 from BRAD.rag import create_database
@@ -1025,6 +1028,53 @@ def sessions_rename(request):
     except Exception as e:
         logger.error(f"An error occurred while trying to rename session '{session_name}': {str(e)}")
         return jsonify({"success": False, "message": f"Error removing session: {str(e)}"}), 500
+
+@bp.route("/llm/get", methods=['GET'])
+def ep_llm_get():
+    return llm_get()
+
+def llm_get():
+    """
+    Get the available OpenAI LLM models.
+
+    This endpoint returns a list of possible LLM models that can be used.
+
+    Request Structure:
+    The request must contain a JSON body with the following fields:
+
+        >>> GET /llm/get
+
+    Successful response example:
+    
+        >>> {
+        >>>     "success": true,
+        >>>     "models": [
+        >>>         "model name 1",
+        >>>         "model name 1",
+        >>>         ...
+        >>>     ]
+        >>> }
+
+    :return: A JSON response indicating success and the name of the active LLM.
+    :rtype: dict
+    """
+    # Auth: Joshua Pickard
+    #       jpic@umich.edu
+    # Date: October 20, 2024
+    try:
+        client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+        models = []
+        for model in client.models.list():
+            models.append(model.id)
+        response = jsonify({"success": True, "models": models})
+        return response, 200
+    except:
+        response = jsonify({
+            "success": False, 
+            "message": "Unknown error incountered by /llms/get/"
+        })
+        return response, 500
+
 
 @bp.route("/llm/set", methods=['POST'])
 def ep_llm_set():

--- a/BRAD/endpoints.py
+++ b/BRAD/endpoints.py
@@ -384,7 +384,7 @@ def databases_create(request):
 
 @bp.route("/databases/available", methods=['GET'])
 def ep_databases_available():
-    return databases_available(request)
+    return databases_available()
 
 def databases_available():
     """

--- a/BRAD/log.py
+++ b/BRAD/log.py
@@ -151,7 +151,7 @@ def logger(chatlog, state, chatname, elapsed_time=None):
         json.dump(chatlog, fp, indent=4)
     return chatlog, state
 
-def llmCallLog(llm=None, memory=None, prompt=None, input=None, output=None, parsedOutput=None, purpose=None):
+def llmCallLog(llm=None, memory=None, prompt=None, input=None, output=None, parsedOutput=None, apiInfo=None, purpose=None):
     """
     Logs the information for each LLM call, capturing relevant details for tracking and debugging. This can
     include both raw and processed outputs, as well as the context of the call.
@@ -179,6 +179,10 @@ def llmCallLog(llm=None, memory=None, prompt=None, input=None, output=None, pars
     :param parsedOutput: The processed or parsed output that is actually used or displayed. This can be a subset 
                          or reformatted version of the full LLM output, focusing on the most relevant information.
     :type parsedOutput: any, optional
+
+    :param apiInfo: The callback information regarding LLM api utilization and fees
+
+    :type apiInfo: dict, optional
     
     :param purpose: A description of the purpose of the LLM call. This field explains why the LLM was called and
                     what task or goal the call is intended to achieve (e.g., generate response, extract information).
@@ -201,6 +205,7 @@ def llmCallLog(llm=None, memory=None, prompt=None, input=None, output=None, pars
         'input'        : str(input),   # full input to LLM
         'output'       : str(output),  # full output from LLM
         'parsedOutput' : parsedOutput, # used output information
+        'api-info'     : apiInfo,      # information about LLM api utilization
         'purpose'      : str(purpose)  # why is this llm call needed?
     }
     return llmLog

--- a/BRAD/rag.py
+++ b/BRAD/rag.py
@@ -186,6 +186,7 @@ def queryDocs(state):
                 input=prompt,
                 output=response,
                 parsedOutput=state['output'],
+                apiInfo=response['metadata']['call back'],
                 purpose='RAG'
             )
         )
@@ -202,7 +203,7 @@ def queryDocs(state):
         # Invoke LLM tracking its usage
         start_time = time.time()
         with get_openai_callback() as cb:
-            response = conversation.predict(input=prompt)        
+            response = conversation.predict(input=prompt)
         responseDetails = {
             'content' : response,
             'time' : time.time() - start_time,
@@ -221,6 +222,7 @@ def queryDocs(state):
                 input=prompt,
                 output=responseDetails,
                 parsedOutput=response,
+                apiInfo=responseDetails['call back'],
                 purpose='chat without RAG'
             )
         )

--- a/brad-chat/src/components/RightSideBar.js
+++ b/brad-chat/src/components/RightSideBar.js
@@ -9,6 +9,37 @@ function RightSideBar({ setColorScheme }) {
   const [llmChoice, setLlmChoice] = useState("gpt-3.5-turbo-0125");  // Default to GPT-4
   const [isApiEntryVisible, setIsApiEntryVisible] = useState(false); // Only if you want to show/hide the popup
   const [availableDatabases, setAvailableDatabases] = useState([]);  // Hold available databases
+  const [availableLLMs, setAvailableLLMs] = useState([]);  // State to hold fetched LLM models
+  const [loading, setLoading] = useState(true);  // State to track loading
+
+  // Fetch available LLM models on component mount
+  // Fetch available LLM models on component mount
+  useEffect(() => {
+    const fetchLLMs = async () => {
+      try {
+        console.log('Fetching available LLM models...');
+        const response = await fetch('/api/llm/get');  // Fetch from your new endpoint
+        console.log('Response:', response);  // Log the entire response
+        const data = await response.json();
+        
+        console.log('Response data:', data);  // Log the entire response
+
+        if (data.success && Array.isArray(data.models)) {
+          setAvailableLLMs(data.models);  // Update available LLM models
+          setLoading(false);  // Stop loading once data is fetched
+        } else {
+          console.error("Failed to fetch LLM models or incorrect response format.");
+          /* TODO: handle this error */
+        }
+      } catch (error) {
+        console.error('Error fetching LLM models:', error);
+        /* TODO: handle fetch error */
+      }
+    };
+
+    fetchLLMs();  // Call the function to fetch LLM models
+  }, []);  // Empty dependency array means this will run only once when the component mounts
+
 
   // Function to handle LLM change
   const handleLlmChange = async (event) => {
@@ -74,10 +105,18 @@ function RightSideBar({ setColorScheme }) {
       <div className="setting-option">
         <label htmlFor="llm-choice">Choose LLM:</label>
         <select id="llm-choice" value={llmChoice} onChange={handleLlmChange}>
-          <option value="gpt-3.5-turbo-0125">GPT-3.5</option>
-          <option value="gpt-4o-mini-2024-07-18">GPT-4</option>
+          {availableLLMs.length > 0 ? (
+            availableLLMs.map((model, index) => (
+              <option key={index} value={model}>
+                {model}
+              </option>
+            ))
+          ) : (
+            <option value="" disabled>Loading models...</option>
+          )}
         </select>
       </div>
+
 
       <RagFileInput />
       <ThemeChangeButton />


### PR DESCRIPTION
ADD: /invoke returns LLM utilization for the RAG in the form of
```
    >>> { 
    >>>      "response": "Generated response from BRAD agent", 
    >>>      "response-log": { 
    >>>          "stage_1": "log entry for stage 1", 
    >>>          "stage_2": "log entry for stage 2", 
    >>>          ...
    >>>      },
    >>>      "llm-usage": {
    >>>          "llm-calls": number of new llm calls,
    >>>          "api-fees":  cost of api fees,
    >>>      }
    >>> }
```
ADD: right side bar populates with every available openai llm. Note, this requires the user to make sure they know what the model is going to do